### PR TITLE
Add optional goal icons to WOTH panel and make gossip stone count configurable

### DIFF
--- a/GSTHD/Layout.cs
+++ b/GSTHD/Layout.cs
@@ -557,7 +557,11 @@ namespace GSTHD
         public int LabelHeight { get; set; }
 
         public Size GossipStoneSize { get; set; }
+        public int GossipStoneCount { get; set; } = 4;
         public string[] GossipStoneImageCollection { get; set; }
+
+        public int PathGoalCount { get; set; } = 0;
+        public string[] GoalImageCollection { get; set; }
     }
 
     public class ObjectPanelBarren

--- a/GSTHD/PanelWothBarren.cs
+++ b/GSTHD/PanelWothBarren.cs
@@ -16,7 +16,10 @@ namespace GSTHD
         public List<Barren> ListBarren = new List<Barren>();
 
         public TextBoxCustom textBoxCustom;
+        private int NbMaxWothItems;
         private string[] ListImage_WothItemsOption;
+        private int NbMaxGoals;
+        private string[] ListImage_GoalsOption;
         Size GossipStoneSize;
         int NbMaxRows;
         Label LabelSettings = new Label();
@@ -92,7 +95,10 @@ namespace GSTHD
 
         public void PanelWoth(Dictionary<string, string> PlacesWithTag, ObjectPanelWotH data)
         {
+            NbMaxWothItems = data.GossipStoneCount;
             ListImage_WothItemsOption = data.GossipStoneImageCollection;
+            NbMaxGoals = data.PathGoalCount;
+            ListImage_GoalsOption = data.GoalImageCollection;
             NbMaxRows = data.NbMaxRows;
 
             LabelSettings = new Label
@@ -207,11 +213,11 @@ namespace GSTHD
                         {
                             WotH newWotH = null;
                             if (ListWotH.Count <= 0)
-                                newWotH = new WotH(Settings, selectedPlace, ListImage_WothItemsOption, new Point(2, -LabelSettings.Height), LabelSettings, GossipStoneSize);
+                                newWotH = new WotH(Settings, selectedPlace, NbMaxWothItems, ListImage_WothItemsOption, NbMaxGoals, ListImage_GoalsOption, new Point(2, -LabelSettings.Height), LabelSettings, GossipStoneSize);
                             else
                             {
                                 var lastLocation = ListWotH.Last().LabelPlace.Location;
-                                newWotH = new WotH(Settings, selectedPlace, ListImage_WothItemsOption, lastLocation, LabelSettings, GossipStoneSize);
+                                newWotH = new WotH(Settings, selectedPlace, NbMaxWothItems, ListImage_WothItemsOption, NbMaxGoals, ListImage_GoalsOption, lastLocation, LabelSettings, GossipStoneSize);
                                
                             }
                             ListWotH.Add(newWotH);
@@ -264,12 +270,13 @@ namespace GSTHD
             for (int i = 0; i < ListWotH.Count; i++)
             {
                 var wothLabel = ListWotH[i].LabelPlace;
-                wothLabel.Location = new Point(2, (i * wothLabel.Height));
+                var newY = i * wothLabel.Height;
+                wothLabel.Location = new Point(wothLabel.Left, newY);
 
                 for (int j = 0; j < ListWotH[i].listGossipStone.Count; j++)
                 {
-                    ListWotH[i].listGossipStone[j].Location = 
-                        new Point(wothLabel.Width + 5 + (j * (ListWotH[i].listGossipStone[j].Width+2)), wothLabel.Location.Y);
+                    var newX = ListWotH[i].listGossipStone[j].Location.X;
+                    ListWotH[i].listGossipStone[j].Location = new Point(newX, newY);
                 }
             }
             textBoxCustom.newLocation(new Point(2, ListWotH.Count * woth.LabelPlace.Height), this.Location);

--- a/GSTHD/WotH.cs
+++ b/GSTHD/WotH.cs
@@ -20,10 +20,19 @@ namespace GSTHD
         private int ColorIndex;
         private int MinIndex;
 
-        public WotH(Settings settings, string selectedPlace, string[] listImage, Point lastLabelLocation, Label labelSettings, Size gossipStoneSize)
+        public WotH(Settings settings, string selectedPlace, int wothItemCount, string[] wothItemImageList, int pathGoalCount, string[] pathGoalImageList, Point lastLabelLocation, Label labelSettings, Size gossipStoneSize)
         {
             Settings = settings;
             Name = selectedPlace;
+
+            int goalStoneStartX = 2;
+            int labelStartX = 2;
+            int labelWidth = labelSettings.Width;
+            if (pathGoalCount > 0)
+            {
+                labelStartX += pathGoalCount * gossipStoneSize.Width + 4;
+            }
+            int gossipStoneStartX = labelStartX + labelWidth + 3;
 
             LabelPlace = new Label
             {
@@ -32,20 +41,31 @@ namespace GSTHD
                 ForeColor = labelSettings.ForeColor,
                 BackColor = labelSettings.BackColor,
                 Font = labelSettings.Font,
-                Width = labelSettings.Width,
+                Width = labelWidth,
                 Height = labelSettings.Height,
                 TextAlign = ContentAlignment.MiddleLeft,
             };
-            LabelPlace.Location = new Point(2, lastLabelLocation.Y + LabelPlace.Height);
+            LabelPlace.Location = new Point(labelStartX, lastLabelLocation.Y + LabelPlace.Height);
             LabelPlace.MouseDown += new MouseEventHandler(label_woth_MouseDown);
 
-            if (listImage.Length > 0)
+            if (wothItemImageList.Length > 0)
             {
-                for (int i = 0; i < 4; i++)
+                for (int i = 0; i < wothItemCount; i++)
                 {
-                    GossipStone newGossipStone = new GossipStone(Settings, Name + "_GossipStone" + i, 0, 0, listImage, gossipStoneSize);
+                    GossipStone newGossipStone = new GossipStone(Settings, Name + "_GossipStone" + i, 0, 0, wothItemImageList, gossipStoneSize);
                     newGossipStone.Location =
-                        new Point(LabelPlace.Width + 5 + ((newGossipStone.Width + 2) * i), LabelPlace.Location.Y);
+                        new Point(gossipStoneStartX + ((newGossipStone.Width + 2) * i), LabelPlace.Location.Y);
+                    listGossipStone.Add(newGossipStone);
+                }
+            }
+
+            if (pathGoalImageList?.Length > 0)
+            {
+                for (int i = 0; i < pathGoalCount; i++)
+                {
+                    GossipStone newGossipStone = new GossipStone(Settings, Name + "_GoalGossipStone" + i, 0, 0, pathGoalImageList, gossipStoneSize);
+                    newGossipStone.Location =
+                        new Point(goalStoneStartX + ((newGossipStone.Width + 2) * i), LabelPlace.Location.Y);
                     listGossipStone.Add(newGossipStone);
                 }
             }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ ___
 - It is now possible to add generic (no autofill) text boxes to a layout.
 - Layouts can now set the order of dungeon names under medallions, as well as the starting value.
 - Different behaviours for Song Markers are now available (`None`, `CheckOnly`, `DropOnly`, `DropAndCheck`, `DragAndDrop`, `Full`).
+- New Path indicators in WOTH pannel. Gossip Stones can be configured to automatically populated to the left of a WOTH location to indicate the path the location is one.
+- The number of gossip stones tracking items from a WOTH location can be configured with the `GossipStoneCount` property in the layout.
 
 #### Other changes and fixes
 - Fixed small issues with collected items' number display.


### PR DESCRIPTION
- Add layout option that adds a configurable number of gossip stones to
the left of a WOTH entry for indicating which Goal path(s) the hint
is for.
- Add layout option that configures the number of gossip stones for the
WOTH item list instead of always using 4.